### PR TITLE
fix: Unnecessary "elif" after "return"

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -21,11 +21,11 @@ def penn_to_wn(tag):
     """
     if tag.startswith('J'):
         return wn.ADJ
-    elif tag.startswith('N'):
+    if tag.startswith('N'):
         return wn.NOUN
-    elif tag.startswith('R'):
+    if tag.startswith('R'):
         return wn.ADV
-    elif tag.startswith('V'):
+    if tag.startswith('V'):
         return wn.VERB
     return None
 


### PR DESCRIPTION
Fixed Unnecessary "elif" after "return"